### PR TITLE
add new domain for bskyx and add gallery view

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ We're not affiliated with any of these services.
 - [fxTikTok](https://github.com/okdargy/fxTikTok)
 - [FixReddit](https://github.com/MinnDevelopment/fxreddit)
 - [FixThreads](https://github.com/milanmdev/fixthreads)
-- [VixBluesky](https://github.com/Rapougnac/VixBluesky)
+- [VixBluesky](https://github.com/Lexedia/VixBluesky)
 - [phixiv](https://github.com/thelaao/phixiv)
 - [EmbedEZ](https://embedez.com)
 - [xfuraffinity](https://github.com/FirraWoof/xfuraffinity)

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Here's, for the record, a non-exhaustive list of the fixers/proxies spotted in t
 - YouTube
   - [Koutube • koutube.com](https://github.com/iGerman00/koutube) *Used by FixTweetBot*
 - Bluesky
-  - [VixBluesky • bskyx.app](https://github.com/Rapougnac/VixBluesky) *Used by FixTweetBot*
+  - [VixBluesky • bskx.app](https://github.com/Lexedia/VixBluesky) *Used by FixTweetBot*
 - Roblox
   - [Rxblox2 • fixroblox.com](https://github.com/vys69/Rxblox2)
 - Snapchat

--- a/database/migrations/2025_01_06_222619_new_bluesky_view.py
+++ b/database/migrations/2025_01_06_222619_new_bluesky_view.py
@@ -1,0 +1,19 @@
+"""NewBlueskyView Migration."""
+
+from masoniteorm.migrations import Migration
+
+
+class NewBlueskyView(Migration):
+    def up(self):
+        """
+        Run the migrations.
+        """
+        with self.schema.table("guilds") as table:
+            table.enum('bluesky_view', ['normal', 'direct_media', 'gallery']).default('normal').change()
+
+    def down(self):
+        """
+        Revert the migrations.
+        """
+        with self.schema.table("guilds") as table:
+            table.enum('bluesky_view', ['normal', 'direct_media']).default('normal').change()

--- a/database/models/Guild.py
+++ b/database/models/Guild.py
@@ -48,6 +48,7 @@ class TiktokView(Enum):
 class BlueskyView(Enum):
     NORMAL = 'normal'
     DIRECT_MEDIA = 'direct_media'
+    GALLERY = 'gallery'
 
     def get(self, value: str) -> Self:
         return self.__members__.get(value)

--- a/src/settings.py
+++ b/src/settings.py
@@ -846,7 +846,7 @@ class BlueskySetting(WebsiteBaseSetting):
     name = 'Bluesky'
     emoji = discore.config.emoji.bluesky
     proxy_name = "VixBluesky"
-    proxy_url = "https://github.com/Rapougnac/VixBluesky"
+    proxy_url = "https://github.com/Lexedia/VixBluesky"
 
 
 class PixivSetting(WebsiteBaseSetting):

--- a/src/websites.py
+++ b/src/websites.py
@@ -351,13 +351,14 @@ class BlueskyLink(WebsiteLink):
 
     @property
     def fix_domain(self) -> str:
-        return "bskyx.app"
+        return "bsky.app"
 
     @property
     def subdomains(self) -> dict:
         return {
             BlueskyView.NORMAL: '',
             BlueskyView.DIRECT_MEDIA: 'r.',
+            BlueskyView.GALLERY: 'g.',
         }
 
     @property

--- a/src/websites.py
+++ b/src/websites.py
@@ -351,7 +351,7 @@ class BlueskyLink(WebsiteLink):
 
     @property
     def fix_domain(self) -> str:
-        return "bsky.app"
+        return "bskx.app"
 
     @property
     def subdomains(self) -> dict:


### PR DESCRIPTION
Hi!
VixBluesky now lives at `bskx.app` because I'm an idiot, `bskyx.app` still works, but it's considered deprecated now.

I also added the gallery view because it's now supported. So uh, yeh.

I also created a small wiki page here https://github.com/Lexedia/VixBluesky/wiki/Features
