### PR TITLE
Add silent reply option, enabled by default

### DIFF
--- a/cogs/link_fix.py
+++ b/cogs/link_fix.py
@@ -124,11 +124,11 @@ async def send_fixed_links(fixed_links: list[str], guild: Guild, original_messag
 
     messages = group_join(fixed_links, 2000)
 
-    if guild.reply:
-        await discore.fallback_reply(original_message, messages.pop(0))
+    if guild.reply_to_message:
+        await discore.fallback_reply(original_message, messages.pop(0), silent=guild.reply_silently)
 
     for message in messages:
-        await original_message.channel.send(message)
+        await original_message.channel.send(message, silent=guild.reply_silently)
 
 
 async def edit_original_message(guild: Guild, message: discore.Message, permissions: discore.Permissions) -> None:

--- a/database/migrations/2025_06_03_021604_add_silent_replies.py
+++ b/database/migrations/2025_06_03_021604_add_silent_replies.py
@@ -1,0 +1,23 @@
+"""AddSilentReplies Migration."""
+
+from masoniteorm.migrations import Migration
+
+
+class AddSilentReplies(Migration):
+    def up(self):
+        """
+        Run the migrations.
+        """
+        with self.schema.table("guilds") as table:
+            table.rename("reply", "reply_to_message", "boolean")
+            table.boolean("reply_to_message").default(False).change()
+            table.boolean("reply_silently").after("reply").default(True)
+
+    def down(self):
+        """
+        Revert the migrations.
+        """
+        with self.schema.table("guilds") as table:
+            table.rename("reply_to_message", "reply", "boolean")
+            table.boolean("reply").default(False).change()
+            table.drop_column("reply_silently")

--- a/database/models/Guild.py
+++ b/database/models/Guild.py
@@ -63,7 +63,8 @@ class Guild(Model):
     __table__ = "guilds"
 
     __casts__ = {
-        'reply': 'bool',
+        'reply_to_message': 'bool',
+        'reply_silently': 'bool',
         'webhooks': 'bool',
         'original_message': OriginalMessage,
         'twitter_view': TwitterView,

--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -140,13 +140,16 @@ settings:
   reply_method:
     name: "Reply method"
     description: "Change the behavior on the reply"
-    content: "**Change what to do on the reply**\n%{state}%{perms}"
+    content: "**Change what to do on the reply**\n- %{state}%{perms}\n- %{silent}"
     button:
       "true": "Replying"
       "false": "Sending"
     state:
       "true": "%{emoji} Replying to messages"
       "false": "📨 Just sending the message"
+    silent:
+      "true": "🔕 Messages will be sent silently"
+      "false": "🔔 Messages will be sent normally"
   webhooks:
     name: "Webhooks"
     description: "Enable/Disable for webhooks"

--- a/src/settings.py
+++ b/src/settings.py
@@ -607,7 +607,8 @@ class ReplyMethodSetting(BaseSetting):
         db_guild = Guild.find_or_create(channel.guild.id)
         self.db_guild = db_guild
         self.channel = channel
-        self.state = bool(db_guild.reply)
+        self.reply_to_message = bool(db_guild.reply_to_message)
+        self.reply_silently = bool(db_guild.reply_silently)
         super().__init__(interaction, view)
 
     @property
@@ -619,13 +620,14 @@ class ReplyMethodSetting(BaseSetting):
         ]
         if isinstance(self.channel, discore.Thread):
             perms.append('send_messages_in_threads')
-        if self.state:
+        if self.reply_to_message:
             perms.append('read_message_history')
         embed = discore.Embed(
             title=f"{self.emoji} {t(self.name)}",
             description=t(
                 'settings.reply_method.content',
-                state=t(f'settings.reply_method.state.{str(self.state).lower()}', emoji=self.emoji),
+                state=t(f'settings.reply_method.state.{str(self.reply_to_message).lower()}', emoji=self.emoji),
+                silent=t(f'settings.reply_method.silent.{str(self.reply_silently).lower()}'),
                 perms=format_perms(perms, self.channel))
         )
         discore.set_embed_footer(self.bot, embed)
@@ -634,7 +636,7 @@ class ReplyMethodSetting(BaseSetting):
     @property
     async def option(self) -> discore.SelectOption:
         return discore.SelectOption(
-            label=('⚠️ ' if self.state and is_missing_perm(['read_message_history'], self.channel) else '')
+            label=('⚠️ ' if self.reply_to_message and is_missing_perm(['read_message_history'], self.channel) else '')
                   + t(self.name),
             value=self.id,
             description=t(self.description),
@@ -643,17 +645,28 @@ class ReplyMethodSetting(BaseSetting):
 
     @property
     async def items(self) -> List[discore.ui.Item]:
-        item = discore.ui.Button(
-            style=discore.ButtonStyle.primary if self.state else discore.ButtonStyle.secondary,
-            label=t(f'settings.reply_method.button.{str(self.state).lower()}'),
+        reply_to_message_button = discore.ui.Button(
+            style=discore.ButtonStyle.primary if self.reply_to_message else discore.ButtonStyle.secondary,
+            label=t(f'settings.reply_method.button.{str(self.reply_to_message).lower()}'),
             custom_id=self.id
         )
-        edit_callback(item, self.view, self.action)
-        return [item]
+        edit_callback(reply_to_message_button, self.view, self.toggle_reply_to_message)
+        reply_silently_button = discore.ui.Button(
+            style=discore.ButtonStyle.secondary if self.reply_silently else discore.ButtonStyle.primary,
+            label=t(f'settings.reply_method.silent.{str(self.reply_silently).lower()}'),
+            custom_id='reply_silently'
+        )
+        edit_callback(reply_silently_button, self.view, self.toggle_reply_silently)
+        return [reply_to_message_button, reply_silently_button]
 
-    async def action(self, view: SettingsView, interaction: discore.Interaction, _) -> None:
-        self.state = not self.state
-        self.db_guild.update({'reply': self.state})
+    async def toggle_reply_to_message(self, view: SettingsView, interaction: discore.Interaction, _) -> None:
+        self.reply_to_message = not self.reply_to_message
+        self.db_guild.update({'reply': self.reply_to_message})
+        await view.refresh(interaction)
+
+    async def toggle_reply_silently(self, view: SettingsView, interaction: discore.Interaction, _) -> None:
+        self.reply_silently = not self.reply_silently
+        self.db_guild.update({'reply_silently': self.reply_silently})
         await view.refresh(interaction)
 
 


### PR DESCRIPTION
## Summary

- Add optional silent reply functionality to reduce unnecessary notifications in
  busy channels
- Implement `reply_silently` toggle in guild settings (defaults to silent)
- Rename `reply` field to `reply_to_message` for clarity and add new
  `reply_silently` boolean field
- Update reply handling in `send_fixed_links` to respect silent setting for both
  replies and regular messages

## Changes

- **Database**: Add migration to rename `reply` → `reply_to_message` and add
  `reply_silently` field (default: true)
- **Models**: Update Guild model to include both reply settings with proper casting
- **Settings UI**: Enhanced reply method setting with two separate toggle buttons
  for reply behavior and silent mode
- **Link fixing**: Modified `send_fixed_links` to use `silent` parameter in both
  `fallback_reply` and `send` calls
- **Localization**: Added silent reply strings to en-US locale

## Implementation Details

  This resolves #37 by implementing Discord's native silent message feature.
  The bot can now send fixed links without generating notifications, making it less
  disruptive in active servers while maintaining full functionality.

  The feature is optional with silent replies enabled by default as suggested by the
  maintainer, but users can toggle this behavior through the settings interface.
