### PR TITLE
fix: remove default value from JSON column in migration

### DIFF
--- a/database/migrations/2025_06_08_104941_deny_allow_lists_guilds.py
+++ b/database/migrations/2025_06_08_104941_deny_allow_lists_guilds.py
@@ -9,7 +9,7 @@ class DenyAllowListsGuilds(Migration):
         Run the migrations.
         """
         with self.schema.table("guilds") as table:
-            table.json("keywords").index().default("[\"fxignore\"]").after("id")
+            table.json("keywords").nullable().after("id")
 
             table.boolean("keywords_use_allow_list").index().default(False).after("keywords")
             table.boolean("text_channels_use_allow_list").index().default(False).after("keywords_use_allow_list")

--- a/database/models/Guild.py
+++ b/database/models/Guild.py
@@ -98,5 +98,6 @@ class Guild(DiscordRepresentation):
     def find_or_create(cls, d_guild: discore.Guild, **kwargs):
         guild = cls.find(d_guild.id)
         if guild is None:
-            guild = cls.create({'id': d_guild.id, **kwargs}).fresh()
+            defaults = {'keywords': '["fxignore"]', **kwargs}
+            guild = cls.create({'id': d_guild.id, **defaults}).fresh()
         return guild


### PR DESCRIPTION
This PR fixes a MySQL error that occurred when running migrations with Docker Compose: `BLOB, TEXT, GEOMETRY or JSON column 'keywords' can't have a default value`.

**Background:**
While MySQL 8.0.13+ supports default values for JSON columns when written as expressions (e.g., `DEFAULT ('["fxignore"]')`), MasoniteORM's `.default()` method generates SQL without the required parentheses, causing the migration to fail. Moving the default value to the application layer is a cleaner, more portable solution that works across all MySQL versions.

**Changes:**
- Removed `.default("[\"fxignore\"]")` from the JSON column definition in the migration
- Made the `keywords` column nullable instead
- Moved the default value logic to the `Guild.find_or_create()` method in the model layer

This ensures MySQL compatibility while maintaining the same functional behavior.

This fixes #74 