### PR TITLE
➕ facebook: add one more group URL pattern

### DIFF
--- a/src/websites.py
+++ b/src/websites.py
@@ -508,6 +508,7 @@ class FacebookLink(GenericWebsiteLink):
             "/watch": ['v'],
             "/permalink.php": ['story_fbid', 'id'],
             "/groups/:id/:type(posts|permalink)/:hash": None,
+            "/groups/:id": ['multi_permalinks'],
     })
 
 


### PR DESCRIPTION
Example URL:
```
https://www.facebook.com/groups/364997627165697/?multi_permalinks=2845630405769061&hoisted_section_header_type=recently_seen
```