### PR TITLE
fix: use correct operator precedence in URL construction

### DIFF
--- a/src/websites.py
+++ b/src/websites.py
@@ -213,7 +213,7 @@ class GenericWebsiteLink(WebsiteLink):
             query_string_repl = '?' + '&'.join(rf"{param}=\g<{param}>" for param in params)
 
         return (
-            "https" if self.is_ssl else "http"
+            ("https" if self.is_ssl else "http")
             + "://{domain}"
             + route_repl
             + "{post_path_segments}"


### PR DESCRIPTION
When HTTP support was added (d193310), a regression was introduced that caused all HTTPS URLs to return only `https` without the rest of the URL:

```
[Threads](<https>) • [@***](<https***>) • [FixThreads](https)
```

This is caused by Python's operator precedence — `+` binds tighter than the ternary `if/else`, so:

```python
"https" if self.is_ssl else "http"
+ "://{domain}"
+ route_repl
```

evaluates as:

```python
"https" if self.is_ssl else ("http" + "://{domain}" + route_repl)
```

Since `is_ssl` defaults to `True` for all websites, `get_repl()` always returns just `"https"`.

The fix adds parentheses around the ternary expression:

```python
("https" if self.is_ssl else "http")
+ "://{domain}"
+ route_repl
```
