### PR TITLE
Add option to send replies as original author replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The required scopes are:
 And the required permissions:
 - Embed Links
 - Manage Messages
+- Manage Webhooks
 - Read Message History
 - Send Messages
 - Send Messages in Threads

--- a/cogs/link_fix.py
+++ b/cogs/link_fix.py
@@ -136,11 +136,17 @@ async def fix_embeds(
         or (isinstance(channel, discore.Thread) and (channel.locked or channel.archived))):
         return
 
-    async with Typing(channel):
+    async def render_and_send() -> tuple[list[tuple[str, list[WebsiteLink]]], dict[discore.Message, list[WebsiteLink]]]:
         rendered_links = [link for link in links if await link.render()]
         if not rendered_links:
-            return
-        not_sent, messages = await send_fixed_links(rendered_links, guild, original_message)
+            return [], {}
+        return await send_fixed_links(rendered_links, guild, original_message)
+
+    if guild.reply_as_original_author_replica:
+        not_sent, messages = await render_and_send()
+    else:
+        async with Typing(channel):
+            not_sent, messages = await render_and_send()
 
     to_delete = []
     if messages:
@@ -200,9 +206,13 @@ async def send_fixed_links(
     links_failed: list[tuple[str, list[WebsiteLink]]] = []
 
     grouped = group_items(rendered_links, 2000)
+    use_original_author_replica = guild.reply_as_original_author_replica
+    webhook = await get_or_create_webhook(original_message.channel) if use_original_author_replica else None
 
     for i, (message_content, links_in_group) in enumerate(grouped):
-        if i == 0 and guild.reply_to_message:
+        if webhook is not None:
+            coro = webhook_send(webhook, original_message, message_content, guild.reply_silently)
+        elif i == 0 and guild.reply_to_message:
             coro = discore.fallback_reply(original_message, message_content, silent=guild.reply_silently)
         else:
             coro = original_message.channel.send(message_content, silent=guild.reply_silently)
@@ -214,6 +224,66 @@ async def send_fixed_links(
             links_failed.append((message_content, links_in_group))
 
     return links_failed, messages_sent
+
+
+async def get_or_create_webhook(channel: GuildMessageableChannel) -> discore.Webhook | None:
+    """
+    Get or create the webhook used to send messages as the original author.
+
+    :param channel: the channel to send the fixed links to
+    :return: the webhook to use, if available
+    """
+
+    webhook_channel = channel.parent if isinstance(channel, discore.Thread) else channel
+    if webhook_channel is None:
+        return None
+
+    if not hasattr(webhook_channel, 'webhooks') or not hasattr(webhook_channel, 'create_webhook'):
+        return None
+
+    if not webhook_channel.permissions_for(channel.guild.me).manage_webhooks:
+        return None
+
+    sent, webhooks = await safe_send_coro(webhook_channel.webhooks(), forbidden=True)
+    if not sent:
+        return None
+    webhook_name = channel.guild.me.display_name
+    webhook = next((
+        w for w in webhooks
+        if w.name == webhook_name and getattr(w.user, 'id', None) == channel.guild.me.id
+    ), None)
+    if webhook is not None:
+        return webhook
+    sent, webhook = await safe_send_coro(webhook_channel.create_webhook(name=webhook_name), forbidden=True)
+    return webhook if sent else None
+
+
+async def webhook_send(
+        webhook: discore.Webhook,
+        original_message: discore.Message,
+        content: str,
+        silent: bool
+) -> discore.Message:
+    """
+    Send a fixed link using the original author's display name and avatar.
+
+    :param webhook: the webhook to use
+    :param original_message: the message associated with the context to reply to
+    :param content: the content to send
+    :param silent: whether to send the message silently
+    :return: the message created by the webhook
+    """
+
+    kwargs = {
+        'content': content,
+        'username': original_message.author.display_name,
+        'avatar_url': original_message.author.display_avatar.url,
+        'silent': silent,
+        'wait': True
+    }
+    if isinstance(original_message.channel, discore.Thread):
+        kwargs['thread'] = original_message.channel
+    return await webhook.send(**kwargs)
 
 
 async def wait_for_embed(message: discore.Message) -> bool:

--- a/cogs/link_fix.py
+++ b/cogs/link_fix.py
@@ -214,21 +214,14 @@ async def send_fixed_links(
     webhook = await get_or_create_webhook(original_message.channel, bot) if use_original_author_replica else None
 
     for i, (message_content, links_in_group) in enumerate(grouped):
-        should_reply = i == 0 and guild.reply_to_message
         if webhook is not None:
             coro = webhook_send(webhook, original_message, message_content, guild.reply_silently)
-        elif should_reply:
+        elif i == 0 and guild.reply_to_message:
             coro = discore.fallback_reply(original_message, message_content, silent=guild.reply_silently)
         else:
             coro = original_message.channel.send(message_content, silent=guild.reply_silently)
 
         sent, msg = await safe_send_coro(coro, invalid_form_body='Embed size exceeds maximum size', forbidden=True)
-        if not sent and webhook is not None:
-            if should_reply:
-                coro = discore.fallback_reply(original_message, message_content, silent=guild.reply_silently)
-            else:
-                coro = original_message.channel.send(message_content, silent=guild.reply_silently)
-            sent, msg = await safe_send_coro(coro, invalid_form_body='Embed size exceeds maximum size', forbidden=True)
         if sent and msg:
             messages_sent[msg] = links_in_group
         else:

--- a/cogs/link_fix.py
+++ b/cogs/link_fix.py
@@ -106,13 +106,15 @@ async def _format_link_data(link: WebsiteLink, original_message: discore.Message
 async def fix_embeds(
         original_message: discore.Message,
         guild: Guild,
-        links: List[WebsiteLink]) -> None:
+        links: List[WebsiteLink],
+        bot: discore.Client) -> None:
     """
     Edit the message if necessary, and send the fixed links.
 
     :param original_message: the message to fix
     :param guild: the guild associated with the context
     :param links: the WebsiteLink objects to fix
+    :param bot: the bot sending the fixed links
 
     Remark:
       Discord API, when sending a message with links, first successfully sends
@@ -140,7 +142,7 @@ async def fix_embeds(
         rendered_links = [link for link in links if await link.render()]
         if not rendered_links:
             return [], {}
-        return await send_fixed_links(rendered_links, guild, original_message)
+        return await send_fixed_links(rendered_links, guild, original_message, bot)
 
     if guild.reply_as_original_author_replica:
         not_sent, messages = await render_and_send()
@@ -179,7 +181,8 @@ async def fix_embeds(
 async def send_fixed_links(
         rendered_links: list[WebsiteLink],
         guild: Guild,
-        original_message: discore.Message
+        original_message: discore.Message,
+        bot: discore.Client
 ) -> tuple[list[tuple[str, list[WebsiteLink]]], dict[discore.Message, list[WebsiteLink]]]:
     """
     Send the fixed links to the channel, according to the guild settings and its context
@@ -199,6 +202,7 @@ async def send_fixed_links(
     :param rendered_links: the rendered WebsiteLink objects to send
     :param guild: the guild associated with the context
     :param original_message: the original message associated with the context to reply to
+    :param bot: the bot sending the fixed links
     :return: a tuple containing the list of links that failed to be sent, and a dict of the messages sent with their corresponding links
     """
 
@@ -207,17 +211,24 @@ async def send_fixed_links(
 
     grouped = group_items(rendered_links, 2000)
     use_original_author_replica = guild.reply_as_original_author_replica
-    webhook = await get_or_create_webhook(original_message.channel) if use_original_author_replica else None
+    webhook = await get_or_create_webhook(original_message.channel, bot) if use_original_author_replica else None
 
     for i, (message_content, links_in_group) in enumerate(grouped):
+        should_reply = i == 0 and guild.reply_to_message
         if webhook is not None:
             coro = webhook_send(webhook, original_message, message_content, guild.reply_silently)
-        elif i == 0 and guild.reply_to_message:
+        elif should_reply:
             coro = discore.fallback_reply(original_message, message_content, silent=guild.reply_silently)
         else:
             coro = original_message.channel.send(message_content, silent=guild.reply_silently)
-        
+
         sent, msg = await safe_send_coro(coro, invalid_form_body='Embed size exceeds maximum size', forbidden=True)
+        if not sent and webhook is not None:
+            if should_reply:
+                coro = discore.fallback_reply(original_message, message_content, silent=guild.reply_silently)
+            else:
+                coro = original_message.channel.send(message_content, silent=guild.reply_silently)
+            sent, msg = await safe_send_coro(coro, invalid_form_body='Embed size exceeds maximum size', forbidden=True)
         if sent and msg:
             messages_sent[msg] = links_in_group
         else:
@@ -226,11 +237,12 @@ async def send_fixed_links(
     return links_failed, messages_sent
 
 
-async def get_or_create_webhook(channel: GuildMessageableChannel) -> discore.Webhook | None:
+async def get_or_create_webhook(channel: GuildMessageableChannel, bot: discore.Client) -> discore.Webhook | None:
     """
     Get or create the webhook used to send messages as the original author.
 
     :param channel: the channel to send the fixed links to
+    :param bot: the bot creating or retrieving the webhook
     :return: the webhook to use, if available
     """
 
@@ -244,18 +256,17 @@ async def get_or_create_webhook(channel: GuildMessageableChannel) -> discore.Web
     if not webhook_channel.permissions_for(channel.guild.me).manage_webhooks:
         return None
 
-    sent, webhooks = await safe_send_coro(webhook_channel.webhooks(), forbidden=True)
-    if not sent:
+    success, webhooks = await safe_send_coro(webhook_channel.webhooks(), forbidden=True)
+    if not success:
         return None
-    webhook_name = channel.guild.me.display_name
     webhook = next((
         w for w in webhooks
-        if w.name == webhook_name and getattr(w.user, 'id', None) == channel.guild.me.id
+        if getattr(w.user, 'id', None) == bot.user.id
     ), None)
     if webhook is not None:
         return webhook
-    sent, webhook = await safe_send_coro(webhook_channel.create_webhook(name=webhook_name), forbidden=True)
-    return webhook if sent else None
+    success, webhook = await safe_send_coro(webhook_channel.create_webhook(name=bot.user.display_name), forbidden=True)
+    return webhook if success else None
 
 
 async def webhook_send(
@@ -372,4 +383,4 @@ class LinkFix(discore.Cog,
         if message.webhook_id is not None and not bool(guild.webhooks):
             return
 
-        await fix_embeds(message, guild, links)
+        await fix_embeds(message, guild, links, self.bot)

--- a/cogs/link_fix.py
+++ b/cogs/link_fix.py
@@ -106,15 +106,13 @@ async def _format_link_data(link: WebsiteLink, original_message: discore.Message
 async def fix_embeds(
         original_message: discore.Message,
         guild: Guild,
-        links: List[WebsiteLink],
-        bot: discore.Client) -> None:
+        links: List[WebsiteLink]) -> None:
     """
     Edit the message if necessary, and send the fixed links.
 
     :param original_message: the message to fix
     :param guild: the guild associated with the context
     :param links: the WebsiteLink objects to fix
-    :param bot: the bot sending the fixed links
 
     Remark:
       Discord API, when sending a message with links, first successfully sends
@@ -142,7 +140,7 @@ async def fix_embeds(
         rendered_links = [link for link in links if await link.render()]
         if not rendered_links:
             return [], {}
-        return await send_fixed_links(rendered_links, guild, original_message, bot)
+        return await send_fixed_links(rendered_links, guild, original_message)
 
     if guild.reply_as_original_author_replica:
         not_sent, messages = await render_and_send()
@@ -181,8 +179,7 @@ async def fix_embeds(
 async def send_fixed_links(
         rendered_links: list[WebsiteLink],
         guild: Guild,
-        original_message: discore.Message,
-        bot: discore.Client
+        original_message: discore.Message
 ) -> tuple[list[tuple[str, list[WebsiteLink]]], dict[discore.Message, list[WebsiteLink]]]:
     """
     Send the fixed links to the channel, according to the guild settings and its context
@@ -202,7 +199,6 @@ async def send_fixed_links(
     :param rendered_links: the rendered WebsiteLink objects to send
     :param guild: the guild associated with the context
     :param original_message: the original message associated with the context to reply to
-    :param bot: the bot sending the fixed links
     :return: a tuple containing the list of links that failed to be sent, and a dict of the messages sent with their corresponding links
     """
 
@@ -211,7 +207,7 @@ async def send_fixed_links(
 
     grouped = group_items(rendered_links, 2000)
     use_original_author_replica = guild.reply_as_original_author_replica
-    webhook = await get_or_create_webhook(original_message.channel, bot) if use_original_author_replica else None
+    webhook = await get_or_create_webhook(original_message.channel) if use_original_author_replica else None
 
     for i, (message_content, links_in_group) in enumerate(grouped):
         if webhook is not None:
@@ -230,12 +226,11 @@ async def send_fixed_links(
     return links_failed, messages_sent
 
 
-async def get_or_create_webhook(channel: GuildMessageableChannel, bot: discore.Client) -> discore.Webhook | None:
+async def get_or_create_webhook(channel: GuildMessageableChannel) -> discore.Webhook | None:
     """
     Get or create the webhook used to send messages as the original author.
 
     :param channel: the channel to send the fixed links to
-    :param bot: the bot creating or retrieving the webhook
     :return: the webhook to use, if available
     """
 
@@ -252,6 +247,7 @@ async def get_or_create_webhook(channel: GuildMessageableChannel, bot: discore.C
     success, webhooks = await safe_send_coro(webhook_channel.webhooks(), forbidden=True)
     if not success:
         return None
+    bot = discore.Bot.get()
     webhook = next((
         w for w in webhooks
         if getattr(w.user, 'id', None) == bot.user.id
@@ -376,4 +372,4 @@ class LinkFix(discore.Cog,
         if message.webhook_id is not None and not bool(guild.webhooks):
             return
 
-        await fix_embeds(message, guild, links, self.bot)
+        await fix_embeds(message, guild, links)

--- a/database/migrations/2026_05_19_000000_add_original_author_replica_replies.py
+++ b/database/migrations/2026_05_19_000000_add_original_author_replica_replies.py
@@ -1,0 +1,19 @@
+"""AddOriginalAuthorReplicaReplies Migration."""
+
+from masoniteorm.migrations import Migration
+
+
+class AddOriginalAuthorReplicaReplies(Migration):
+    def up(self):
+        """
+        Run the migrations.
+        """
+        with self.schema.table("guilds") as table:
+            table.boolean("reply_as_original_author_replica").default(False)
+
+    def down(self):
+        """
+        Revert the migrations.
+        """
+        with self.schema.table("guilds") as table:
+            table.drop_column("reply_as_original_author_replica")

--- a/database/migrations/2026_05_26_205445_add_original_author_replica_replies.py
+++ b/database/migrations/2026_05_26_205445_add_original_author_replica_replies.py
@@ -9,7 +9,7 @@ class AddOriginalAuthorReplicaReplies(Migration):
         Run the migrations.
         """
         with self.schema.table("guilds") as table:
-            table.boolean("reply_as_original_author_replica").default(False)
+            table.boolean("reply_as_original_author_replica").after("reply_silently").default(False)
 
     def down(self):
         """

--- a/database/models/Guild.py
+++ b/database/models/Guild.py
@@ -61,6 +61,7 @@ class Guild(DiscordRepresentation):
         'roles_use_any_rule': bool,
         'reply_to_message': bool,
         'reply_silently': bool,
+        'reply_as_original_author_replica': bool,
         'webhooks': bool,
         'original_message': OriginalMessage,
         'twitter_view': FxEmbedView,

--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -56,6 +56,9 @@ settings:
     read_message_history:
       "true": "🟢 `Read message history` permission"
       "false": "🔴 Missing `read message history` permission"
+    manage_webhooks:
+      "true": "🟢 `Manage webhooks` permission"
+      "false": "🔴 Missing `manage webhooks` permission"
   filters:
     button:
       toggle:
@@ -148,7 +151,7 @@ settings:
   reply_method:
     name: "Reply method"
     description: "Change the behavior on the reply"
-    content: "**Change what to do on the reply**\n- %{state}\n- %{silent}%{perms}"
+    content: "**Change what to do on the reply**\n- %{state}\n- %{silent}\n- %{replica}%{perms}"
     reply:
       button:
         "true": "Replying"
@@ -163,6 +166,13 @@ settings:
       state:
         "true": "🔕 Send silently"
         "false": "🔔 Send with a notification"
+    original_author_replica:
+      button:
+        "true": "Send as Original Author Replica"
+        "false": "Send as %{bot}"
+      state:
+        "true": "🪪 Send as Original Author Replica"
+        "false": "🤖 Send as %{bot}"
   webhooks:
     name: "Webhooks"
     description: "Enable/Disable for webhooks"

--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -168,10 +168,10 @@ settings:
         "false": "🔔 Send with a notification"
     original_author_replica:
       button:
-        "true": "Send as Original Author Replica"
+        "true": "Send as original author replica"
         "false": "Send as %{bot}"
       state:
-        "true": "🪪 Send as Original Author Replica"
+        "true": "🪪 Send as original author replica"
         "false": "🤖 Send as %{bot}"
   webhooks:
     name: "Webhooks"

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -53,6 +53,9 @@ settings:
     read_message_history:
       "true": "🟢 `메시지 기록 보기` 권한"
       "false": "🔴 `메시지 기록 보기` 권한 없음"
+    manage_webhooks:
+      "true": "🟢 `웹후크 관리하기` 권한"
+      "false": "🔴 `웹후크 관리하기` 권한 없음"
   filters:
     button:
       toggle:
@@ -145,7 +148,7 @@ settings:
   reply_method:
     name: "답장 방법"
     description: "답장할 때의 동작 변경하기"
-    content: "**답장할 때 수행할 작업 변경하기**\n- %{state}\n- %{silent}%{perms}"
+    content: "**답장할 때 수행할 작업 변경하기**\n- %{state}\n- %{silent}\n- %{replica}%{perms}"
     reply:
       button:
         "true": "답장"
@@ -160,6 +163,13 @@ settings:
       state:
         "true": "🔕 조용히 보내기"
         "false": "🔔 알림과 함께 보내기"
+    original_author_replica:
+      button:
+        "true": "원본 작성자 복제본으로 보내기"
+        "false": "%{bot}(으)로 보내기"
+      state:
+        "true": "🪪 원본 작성자 복제본으로 보내기"
+        "false": "🤖 %{bot}(으)로 보내기"
   webhooks:
     name: "웹후크"
     description: "웹후크 활성화/비활성화하기"

--- a/src/settings.py
+++ b/src/settings.py
@@ -1150,7 +1150,7 @@ class ReplyMethodSetting(BaseSetting):
                 silent=t(f'settings.reply_method.silent.state.{l(self.reply_silently)}'),
                 replica=t(
                     f'settings.reply_method.original_author_replica.state.{l(self.reply_as_original_author_replica)}',
-                    bot=self.ctx.guild.discord_object.me.display_name),
+                    bot=self.bot.user.display_name),
                 perms=format_perms(perms, self.ctx.channel.discord_object))
         )
         discore.set_embed_footer(self.bot, embed)
@@ -1190,7 +1190,7 @@ class ReplyMethodSetting(BaseSetting):
             style=discore.ButtonStyle.primary if self.reply_as_original_author_replica else discore.ButtonStyle.secondary,
             label=t(
                 f'settings.reply_method.original_author_replica.button.{l(self.reply_as_original_author_replica)}',
-                bot=self.ctx.guild.discord_object.me.display_name),
+                bot=self.bot.user.display_name),
             custom_id='reply_as_original_author_replica'
         )
         edit_callback(original_author_replica_button, self.view, self.toggle_reply_as_original_author_replica)

--- a/src/settings.py
+++ b/src/settings.py
@@ -403,6 +403,8 @@ class TroubleshootingSetting(BaseSetting):
             perms.append('manage_messages')
         if self.ctx.guild.reply_to_message:
             perms.append('read_message_history')
+        if self.ctx.guild.reply_as_original_author_replica:
+            perms.append('manage_webhooks')
         embed.add_field(
             name=t('settings.troubleshooting.permissions', channel=self.ctx.channel.mention),
             value=format_perms(perms, self.ctx.channel.discord_object, include_label=False, include_valid=True),
@@ -1123,7 +1125,8 @@ class ReplyMethodSetting(BaseSetting):
 
     def __init__(self, interaction: discore.Interaction, view: SettingsView, ctx: DataElements):
         super().__init__(interaction, view, ctx)
-        self.reply_to_message = bool(ctx.guild.reply_to_message)
+        self.reply_as_original_author_replica = bool(ctx.guild.reply_as_original_author_replica)
+        self.reply_to_message = bool(ctx.guild.reply_to_message and not self.reply_as_original_author_replica)
         self.reply_silently = bool(ctx.guild.reply_silently)
 
     @property
@@ -1137,12 +1140,17 @@ class ReplyMethodSetting(BaseSetting):
             perms.append('send_messages_in_threads')
         if self.reply_to_message:
             perms.append('read_message_history')
+        if self.reply_as_original_author_replica:
+            perms.append('manage_webhooks')
         embed = discore.Embed(
             title=f"{self.emoji} {t(self.name)}",
             description=t(
                 'settings.reply_method.content',
                 state=t(f'settings.reply_method.reply.state.{l(self.reply_to_message)}', emoji=self.emoji),
                 silent=t(f'settings.reply_method.silent.state.{l(self.reply_silently)}'),
+                replica=t(
+                    f'settings.reply_method.original_author_replica.state.{l(self.reply_as_original_author_replica)}',
+                    bot=self.ctx.guild.discord_object.me.display_name),
                 perms=format_perms(perms, self.ctx.channel.discord_object))
         )
         discore.set_embed_footer(self.bot, embed)
@@ -1150,8 +1158,13 @@ class ReplyMethodSetting(BaseSetting):
 
     @property
     async def option(self) -> discore.SelectOption:
+        has_missing_perms = (
+            (self.reply_to_message and is_missing_perm(['read_message_history'], self.ctx.channel.discord_object))
+            or (self.reply_as_original_author_replica
+                and is_missing_perm(['manage_webhooks'], self.ctx.channel.discord_object))
+        )
         return discore.SelectOption(
-            label=('⚠️ ' if self.reply_to_message and is_missing_perm(['read_message_history'], self.ctx.channel.discord_object) else '')
+            label=('⚠️ ' if has_missing_perms else '')
                   + t(self.name),
             value=self.id,
             description=t(self.description),
@@ -1163,7 +1176,8 @@ class ReplyMethodSetting(BaseSetting):
         reply_to_message_button = discore.ui.Button(
             style=discore.ButtonStyle.primary if self.reply_to_message else discore.ButtonStyle.secondary,
             label=t(f'settings.reply_method.reply.button.{l(self.reply_to_message)}'),
-            custom_id=self.id
+            custom_id=self.id,
+            disabled=self.reply_as_original_author_replica
         )
         edit_callback(reply_to_message_button, self.view, self.toggle_reply_to_message)
         reply_silently_button = discore.ui.Button(
@@ -1172,9 +1186,19 @@ class ReplyMethodSetting(BaseSetting):
             custom_id='reply_silently'
         )
         edit_callback(reply_silently_button, self.view, self.toggle_reply_silently)
-        return [reply_to_message_button, reply_silently_button]
+        original_author_replica_button = discore.ui.Button(
+            style=discore.ButtonStyle.primary if self.reply_as_original_author_replica else discore.ButtonStyle.secondary,
+            label=t(
+                f'settings.reply_method.original_author_replica.button.{l(self.reply_as_original_author_replica)}',
+                bot=self.ctx.guild.discord_object.me.display_name),
+            custom_id='reply_as_original_author_replica'
+        )
+        edit_callback(original_author_replica_button, self.view, self.toggle_reply_as_original_author_replica)
+        return [reply_to_message_button, reply_silently_button, original_author_replica_button]
 
     async def toggle_reply_to_message(self, view: SettingsView, interaction: discore.Interaction, _) -> None:
+        if self.reply_as_original_author_replica:
+            return
         self.reply_to_message = not self.reply_to_message
         self.ctx.guild.update({'reply_to_message': self.reply_to_message})
         await view.refresh(interaction)
@@ -1182,6 +1206,16 @@ class ReplyMethodSetting(BaseSetting):
     async def toggle_reply_silently(self, view: SettingsView, interaction: discore.Interaction, _) -> None:
         self.reply_silently = not self.reply_silently
         self.ctx.guild.update({'reply_silently': self.reply_silently})
+        await view.refresh(interaction)
+
+    async def toggle_reply_as_original_author_replica(self, view: SettingsView, interaction: discore.Interaction, _) -> None:
+        self.reply_as_original_author_replica = not self.reply_as_original_author_replica
+        if self.reply_as_original_author_replica:
+            self.reply_to_message = False
+        self.ctx.guild.update({
+            'reply_as_original_author_replica': self.reply_as_original_author_replica,
+            'reply_to_message': self.reply_to_message
+        })
         await view.refresh(interaction)
 
 


### PR DESCRIPTION
## Summary

Adds a new Reply Method option to send fixed-link replies as a replica of the original message author instead of the bot.

This was written with Codex, then tested locally.

## Context

Reference: Discord report  
https://discord.com/channels/1160873160665731134/1215363563791585350

## Changes

- Added a `Send as Original Author Replica` / `Send as %{bot}` toggle
- Sends fixed links through a channel webhook when original author replica mode is enabled
- Uses the original message author's display name and avatar for the webhook message
- Disables reply mode when webhook sending is enabled, since webhooks cannot reply
- Falls back to the normal send path if the webhook cannot be created or retrieved
- Keeps original message handling under the existing Original Message setting
- Adds `Manage Webhooks` permission text, including troubleshooting permissions
- Updates English and Korean locale strings

## Tested

Tested locally after adding the setting column to the local test database.

- Bot starts successfully
- Slash commands sync successfully
- Updated locale YAML files parse successfully
- Python syntax checks pass for the touched files
