### PR TITLE
➕ threads: add `/share` URL pattern

### DIFF
--- a/src/websites.py
+++ b/src/websites.py
@@ -480,6 +480,7 @@ class ThreadsLink(GenericWebsiteLink):
         ["threads.net", "threads.com"],
         {
             "/@:username/post/:id": None,
+            "/share/:hash": None,
     })
 
 


### PR DESCRIPTION
Threads share button started generating `/share` URLs recently.

Example: `https://www.threads.com/share/DoDJmollq/`